### PR TITLE
feat: add capture support for DKUtil::Hook::IDToAbs

### DIFF
--- a/vr_address_tools.py
+++ b/vr_address_tools.py
@@ -40,6 +40,8 @@ VARIANT_ID_PATTERN = r"REL::VariantID\s+(?P<prefix>\w+)\((?P<sse>[0-9]+),+\s*(?P
 # 	return _generic_foo<46261, NodeArray&, NodeArray&, const char*, CombatBehaviorTreeNode*>(array, name, node);
 # }
 GENERIC_FOO_ID = r"_generic_foo<(?P<sse>[0-9]+),"
+# DKUtil IDToAbs, DKUtil uses alphabetical order so AE ID goes first DKUtil::Hook::IDToAbs(50643, 49716)
+DKUTIL_ID_TO_ABS_PATTERN = r"DKUtil::Hook::IDToAbs\((?P<ae>[0-9]+),+\s*(?P<sse>[0-9]*)(?:,+\s*0x(?P<vr_idoffset>[a-f0-9]*))?\)"
 ## These are regexes for parsing offset files that typically can help define relationships (older commonlibvr); po3 and ng now allow for definition through macro use
 # commonlibsse-ng patterns
 # namespace BSSoundHandle
@@ -56,7 +58,12 @@ OFFSET_OFFSET_PATTERN = (
     r"(?:inline|constexpr) REL::Offset\s+(\w+)\s*(?:\(|\{)\s*([a-fx0-9]+)"
 )
 IFNDEF_PATTERN = r"([\w():]*)\s*{\s*#ifndef SKYRIMVR\s*([^{]*){\s*rel::id\(([0-9]*)\)\s}.*\s*#else\s*\2{.*(?:rel::offset)*(0x[0-9a-f]*)"
-RELID_MATCH_ARRAY = [PATTERN_GROUPS, RELOCATION_ID_PATTERN, GENERIC_FOO_ID]
+RELID_MATCH_ARRAY = [
+    PATTERN_GROUPS,
+    RELOCATION_ID_PATTERN,
+    GENERIC_FOO_ID,
+    DKUTIL_ID_TO_ABS_PATTERN,
+]
 REL_ID_VTABLE = "rel::id vtable"
 REL_OFFSET_VTABLE = "rel::offset vtable"
 REL_ID = "rel::id"


### PR DESCRIPTION
Add capture support for DKUtil::Hook::IDToAbs
fix #11 

Tested this code on https://github.com/max-su-2019/CombatPathingRevolution
Before fix: ``python.exe .\vr_address_tools.py ..\CombatPathingRevolution\ analyze``
```
Finished scanning 28 files. rel_ids: 0 offsets: 0 results: 28
src/Backoff_Hook.h:55   ID: 46731       FLAT: 0x1407d97d0       REL::Offset(0x0804b20)  0x140804b20
src/Circling_Hook.cpp:15        ID: 49720       FLAT: 0x140845070       REL::Offset(0x0870320)  0x140870320
src/Circling_Hook.h:19  ID: 49720       FLAT: 0x140845070       REL::Offset(0x0870320)  0x140870320
src/Circling_Hook.h:61  ID: 49721       FLAT: 0x1408450a0       REL::Offset(0x0870350)  0x140870350
src/Fallback_Hook.h:16  ID: 46712       FLAT: 0x1407d73d0       REL::Offset(0x0802720)  0x140802720
src/Util.cpp:101        ID: 46264       FLAT: 0x1407c7a40       REL::Offset(0x07f2d90)  0x1407f2d90
src/Util.cpp:75 ID: 46736       FLAT: 0x1407da290       REL::Offset(0x08055e0)  0x1408055e0
src/Util.cpp:81 ID: 46732       FLAT: 0x1407da060       REL::Offset(0x08053b0)  0x1408053b0
src/Util.cpp:86 ID: 46261       FLAT: 0x1407c7820       REL::Offset(0x07f2b70)  0x1407f2b70
src/Util.cpp:91 ID: 46255       FLAT: 0x1407c7690       REL::Offset(0x07f29e0)  0x1407f29e0
src/Util.cpp:96 ID: 46265       FLAT: 0x1407c7b20       REL::Offset(0x07f2e70)  0x1407f2e70
src\PayloadInterpreter/Dtry_Utils.cpp:23        ID: 511883      FLAT: 0x141e05b2c       REL::Offset(0x1ec569c)  0x141ec569c
src\PayloadInterpreter/Dtry_Utils.cpp:26        ID: 66989       FLAT: 0x140c07900       REL::Offset(0x0c42780)  0x140c42780
src\RE/CombatBehaviorNodesMovement.cpp:10       ID: 46758       FLAT: 0x1407db140       REL::Offset(0x0806490)  0x140806490
src\RE/CombatBehaviorNodesMovement.cpp:11       ID: 46763       FLAT: 0x1407db410       REL::Offset(0x0806760)  0x140806760
src\RE/CombatBehaviorNodesMovement.cpp:12       ID: 46760       FLAT: 0x1407db260       REL::Offset(0x08065b0)  0x1408065b0
src\RE/CombatBehaviorNodesMovement.cpp:13       ID: 46761       FLAT: 0x1407db2f0       REL::Offset(0x0806640)  0x140806640
src\RE/CombatBehaviorNodesMovement.cpp:5        ID: 46753       FLAT: 0x1407dac80       REL::Offset(0x0805fd0)  0x140805fd0
src\RE/CombatBehaviorNodesMovement.cpp:6        ID: 46762       FLAT: 0x1407db380       REL::Offset(0x08066d0)  0x1408066d0
src\RE/CombatBehaviorNodesMovement.cpp:7        ID: 46759       FLAT: 0x1407db1d0       REL::Offset(0x0806520)  0x140806520
src\RE/CombatBehaviorNodesMovement.cpp:8        ID: 46765       FLAT: 0x1407db530       REL::Offset(0x0806880)  0x140806880
src\RE/CombatBehaviorNodesMovement.cpp:9        ID: 46764       FLAT: 0x1407db4a0       REL::Offset(0x08067f0)  0x1408067f0
src\RE/CombatBehaviorTreeControl.h:42   ID: 46229       FLAT: 0x1407c69d0       REL::Offset(0x07f1d20)  0x1407f1d20
src\RE/CombatBehaviorTreeControl.h:47   ID: 46240       FLAT: 0x1407c6d30       REL::Offset(0x07f2080)  0x1407f2080
src\RE/CombatBehaviorTreeNode.h:34      ID: 46305       FLAT: 0x1407c8d40       REL::Offset(0x07f4090)  0x1407f4090
src\RE/CombatBehaviorTreeNode.h:39      ID: 46304       FLAT: 0x1407c8cb0       REL::Offset(0x07f4000)  0x1407f4000
src\RE/CombatBehaviorTreeNode.h:51      ID: 46301       FLAT: 0x1407c8c10       REL::Offset(0x07f3f60)  0x1407f3f60
src\RE/CombatBehaviorTreeNode.h:56      ID: 46302       FLAT: 0x1407c8c40       REL::Offset(0x07f3f90)  0x1407f3f90
Found 28 items
```

After fix: `python.exe .\vr_address_tools.py ..\CombatPathingRevolution\ analyze`
```
Finished scanning 28 files. rel_ids: 0 offsets: 0 results: 30
src/Advance_Hook.h:55   ID: 49716       FLAT: 0x140844e40       REL::Offset(0x08700f0)  0x1408700f0
src/Advance_Hook.h:65   ID: 49716       FLAT: 0x140844e40       REL::Offset(0x08700f0)  0x1408700f0
src/Backoff_Hook.h:55   ID: 46731       FLAT: 0x1407d97d0       REL::Offset(0x0804b20)  0x140804b20
src/Circling_Hook.cpp:15        ID: 49720       FLAT: 0x140845070       REL::Offset(0x0870320)  0x140870320
src/Circling_Hook.h:19  ID: 49720       FLAT: 0x140845070       REL::Offset(0x0870320)  0x140870320
src/Circling_Hook.h:61  ID: 49721       FLAT: 0x1408450a0       REL::Offset(0x0870350)  0x140870350
src/Fallback_Hook.h:16  ID: 46712       FLAT: 0x1407d73d0       REL::Offset(0x0802720)  0x140802720
src/Util.cpp:101        ID: 46264       FLAT: 0x1407c7a40       REL::Offset(0x07f2d90)  0x1407f2d90
src/Util.cpp:75 ID: 46736       FLAT: 0x1407da290       REL::Offset(0x08055e0)  0x1408055e0
src/Util.cpp:81 ID: 46732       FLAT: 0x1407da060       REL::Offset(0x08053b0)  0x1408053b0
src/Util.cpp:86 ID: 46261       FLAT: 0x1407c7820       REL::Offset(0x07f2b70)  0x1407f2b70
src/Util.cpp:91 ID: 46255       FLAT: 0x1407c7690       REL::Offset(0x07f29e0)  0x1407f29e0
src/Util.cpp:96 ID: 46265       FLAT: 0x1407c7b20       REL::Offset(0x07f2e70)  0x1407f2e70
src\PayloadInterpreter/Dtry_Utils.cpp:23        ID: 511883      FLAT: 0x141e05b2c       REL::Offset(0x1ec569c)  0x141ec569c
src\PayloadInterpreter/Dtry_Utils.cpp:26        ID: 66989       FLAT: 0x140c07900       REL::Offset(0x0c42780)  0x140c42780
src\RE/CombatBehaviorNodesMovement.cpp:10       ID: 46758       FLAT: 0x1407db140       REL::Offset(0x0806490)  0x140806490
src\RE/CombatBehaviorNodesMovement.cpp:11       ID: 46763       FLAT: 0x1407db410       REL::Offset(0x0806760)  0x140806760
src\RE/CombatBehaviorNodesMovement.cpp:12       ID: 46760       FLAT: 0x1407db260       REL::Offset(0x08065b0)  0x1408065b0
src\RE/CombatBehaviorNodesMovement.cpp:13       ID: 46761       FLAT: 0x1407db2f0       REL::Offset(0x0806640)  0x140806640
src\RE/CombatBehaviorNodesMovement.cpp:5        ID: 46753       FLAT: 0x1407dac80       REL::Offset(0x0805fd0)  0x140805fd0
src\RE/CombatBehaviorNodesMovement.cpp:6        ID: 46762       FLAT: 0x1407db380       REL::Offset(0x08066d0)  0x1408066d0
src\RE/CombatBehaviorNodesMovement.cpp:7        ID: 46759       FLAT: 0x1407db1d0       REL::Offset(0x0806520)  0x140806520
src\RE/CombatBehaviorNodesMovement.cpp:8        ID: 46765       FLAT: 0x1407db530       REL::Offset(0x0806880)  0x140806880
src\RE/CombatBehaviorNodesMovement.cpp:9        ID: 46764       FLAT: 0x1407db4a0       REL::Offset(0x08067f0)  0x1408067f0
src\RE/CombatBehaviorTreeControl.h:42   ID: 46229       FLAT: 0x1407c69d0       REL::Offset(0x07f1d20)  0x1407f1d20
src\RE/CombatBehaviorTreeControl.h:47   ID: 46240       FLAT: 0x1407c6d30       REL::Offset(0x07f2080)  0x1407f2080
src\RE/CombatBehaviorTreeNode.h:34      ID: 46305       FLAT: 0x1407c8d40       REL::Offset(0x07f4090)  0x1407f4090
src\RE/CombatBehaviorTreeNode.h:39      ID: 46304       FLAT: 0x1407c8cb0       REL::Offset(0x07f4000)  0x1407f4000
src\RE/CombatBehaviorTreeNode.h:51      ID: 46301       FLAT: 0x1407c8c10       REL::Offset(0x07f3f60)  0x1407f3f60
src\RE/CombatBehaviorTreeNode.h:56      ID: 46302       FLAT: 0x1407c8c40       REL::Offset(0x07f3f90)  0x1407f3f90
Found 30 items
```

So on this case it found 2 additional cases (same ids in this case)

```
src/Advance_Hook.h:55   ID: 49716       FLAT: 0x140844e40       REL::Offset(0x08700f0)  0x1408700f0
src/Advance_Hook.h:65   ID: 49716       FLAT: 0x140844e40       REL::Offset(0x08700f0)  0x1408700f0

// The found cases looks like this
DKUtil::Hook::IDToAbs(50643, 49716),
```
So in this case like seen `49716` was found to be SE as expected (DKUtil::Hook::IDToAbs have a non-normal order)
